### PR TITLE
initial commit for ActionMailer, not yet finalized

### DIFF
--- a/app/controllers/trader_controller.rb
+++ b/app/controllers/trader_controller.rb
@@ -27,6 +27,19 @@ class TraderController < ApplicationController
     end
   end 
 
+  # def create_trader
+  #   @trader = Trader.new(trader_params)
+
+  #   if @trader.save
+  #     render json: @trader, status: :ok
+  #     TraderMailer.with(trader: @trader).send_email_receipt.deliver_later
+  #   else
+  #    render json: { errors: @trader.errors.full_messages }, status: 422
+  #   end
+
+  # end
+
+
   private
 
   def trader_params

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,4 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: 'from@example.com'
+  default from: 'dokitomorvin@gmail.com'
   layout 'mailer'
 end

--- a/app/mailers/trader_mailer.rb
+++ b/app/mailers/trader_mailer.rb
@@ -1,0 +1,13 @@
+class TraderMailer < ApplicationMailer
+    default from: 'dokitomorvin@gmail.com'
+
+    def send_email_receipt
+        @trader = params[:trader]
+        from: "support@stockapp.com",
+        mail(to: email_address_with_name(@trader.email, @trader.fullname),
+            subject: "Your registration is succesful"
+        )
+    end
+
+
+end

--- a/app/views/trader_mailer/send_email_receipt.html.erb
+++ b/app/views/trader_mailer/send_email_receipt.html.erb
@@ -1,0 +1,12 @@
+<html>
+  <head>
+    <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
+  </head>
+  <body>
+    <h1>Welcome to Stock App, <%= @trader.fullname %></h1>
+    <p>
+      Congratulations!
+      You have successfully registered to stock app. Please wait for the confirmation of your account.
+    </p>
+  </body>
+</html>

--- a/spec/mailers/previews/trader_preview.rb
+++ b/spec/mailers/previews/trader_preview.rb
@@ -1,0 +1,4 @@
+# Preview all emails at http://localhost:3000/rails/mailers/trader
+class TraderPreview < ActionMailer::Preview
+
+end

--- a/spec/mailers/trader_spec.rb
+++ b/spec/mailers/trader_spec.rb
@@ -1,0 +1,5 @@
+require "rails_helper"
+
+RSpec.describe TraderMailer, type: :mailer do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
Not yet working. 

ActionMailer still needs a create method from trader_controller.rb. There's a commented out create_trader method draft. This also has a template html.erb for email content.  Please check or edit the method/template to fit the app, if necessary. 

